### PR TITLE
Fixing some i18n/encoding issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2076,7 +2076,7 @@ or info related to the entry. <http://sourceforge.net/projects/vpopmail/>
            the wrong order. 
 
 5.0pre6
-09/15/01   Jan Pavlík <gandie@rootshell.cz>
+09/15/01   Jan PavlÃ­k <gandie@rootshell.cz>
          - Hi, i think there is 5 or 6 real_connects but you set 
            MYSQL_PORT for 2 only...
 
@@ -3032,7 +3032,7 @@ Nov 30 - free memory in vcdb.c under error condition
 
 Nov 27 - vsqwebmail_pass was writing over TmpBuf1 in vadduser so
          that the chdir back to the callers directory was not working.
-                 Martin Köster <mk@ezl-data.dk>
+                 Martin KÃ¶ster <mk@ezl-data.dk>
 
 Nov 20 - add a res1=NULL in vmysql.c vauth_getall to make it more
          robust.  Garrett Marone <garrettm@web2010.com>
@@ -3346,7 +3346,7 @@ Jun 10 - Check for : character in gecos field and return error if found.
          : characters are in any of the fields, we have a problem
          parsing the lines.
 
-Jun 07 - Ondøej Surý - fixed possible memory problem with handling
+Jun 07 - OndÃ¸ej SurÃ½ - fixed possible memory problem with handling
          the HOST environment variable in vdelivermail.c 
 
 4.6

--- a/contrib/addusers.pl
+++ b/contrib/addusers.pl
@@ -3,7 +3,7 @@
 # this program will read users and password  from a file
 # that is separated by ":" colons
 #
-# Thanks to "Jürgen Hoffmann" <jh@byteaction.de>
+# Thanks to "JÃ¼rgen Hoffmann" <jh@byteaction.de>
 
 use IO::File;
 


### PR DESCRIPTION
Some author names were mangled during various moves between repository systems... I tracked down original patches and/or other postings on the Internet and fixed the names, all in UTF-8.

Beware of the tricky `contrib/addusers.pl`: since it was in UTF-16LE, github does correctly display it, LoL
![image](https://github.com/user-attachments/assets/071d4d11-f8d0-4d1f-bd2f-9b912702ec57)

![image](https://github.com/user-attachments/assets/389e2406-0f4e-450b-ab61-285eb700518b)

Fixes: https://github.com/DerDakon/vpopmail/issues/2